### PR TITLE
Normalise Source Link File Paths in NuGet Template

### DIFF
--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,6 +4,7 @@
 
   <PropertyGroup Label="Build">
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <PropertyGroup Label="Signing">

--- a/build.cake
+++ b/build.cake
@@ -63,13 +63,19 @@ Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")
     .Does(() =>
     {
+        var buildSettings = new DotNetCoreMSBuildSettings();
+        if (!BuildSystem.IsLocalBuild)
+        {
+            buildSettings.WithProperty("ContinuousIntegrationBuild", "true");
+        }
+
         DotNetCorePack(
             ".",
             new DotNetCorePackSettings()
             {
                 Configuration = configuration,
                 IncludeSymbols = true,
-                MSBuildSettings = new DotNetCoreMSBuildSettings().WithProperty("SymbolPackageFormat", "snupkg"),
+                MSBuildSettings = buildSettings,
                 NoBuild = true,
                 NoRestore = true,
                 OutputDirectory = artefactsDirectory,


### PR DESCRIPTION
- Normalise Source Link File Paths in NuGet Template (see [blog post](https://devblogs.microsoft.com/dotnet/producing-packages-with-source-link/) for more info). This is recommended for source link.
- Move `SymbolPackageFormat` into `Directory.Build.props`.