### PR TITLE
Add support to .NET Core 3.0 and 3.1

### DIFF
--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">


### PR DESCRIPTION
Related Issue: #10 

I've added both 3.0 and 3.1 on the TargetFrameworks tag since the Span fields where introduced in 3.0. It seems to be working just fine in 3.1

![3 1-validation](https://user-images.githubusercontent.com/23037278/103789332-a6a4ef00-501e-11eb-9fe5-13e62884f391.png)
