### PR TITLE
Up Bump .NET SDK from 5.0.100 to 5.0.102

### DIFF
--- a/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
@@ -18,6 +18,7 @@ namespace Serilog.Enrichers.Span
             {
                 ActivityIdFormat.Hierarchical => activity.Id,
                 ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
+                ActivityIdFormat.Unknown => null,
                 _ => null,
             };
 
@@ -35,6 +36,7 @@ namespace Serilog.Enrichers.Span
             {
                 ActivityIdFormat.Hierarchical => activity.RootId,
                 ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
+                ActivityIdFormat.Unknown => null,
                 _ => null,
             };
 
@@ -52,6 +54,7 @@ namespace Serilog.Enrichers.Span
             {
                 ActivityIdFormat.Hierarchical => activity.ParentId,
                 ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
+                ActivityIdFormat.Unknown => null,
                 _ => null,
             };
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,7 @@ build_script:
       Invoke-WebRequest "https://dot.net/v1/dotnet-install.sh" -OutFile "./dotnet-install.sh"
       sudo chmod u+x dotnet-install.sh
       if ($isMacOS) {
-        sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/Users/appveyor/.dotnet'
+        sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/usr/local/share/dotnet'
       } else {
         sudo ./dotnet-install.sh --jsonfile global.json --install-dir '/usr/share/dotnet'
       }

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0001",
+      "version": "1.0.0-rc0002",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestMajor",
-    "version": "5.0.100"
+    "version": "5.0.102"
   }
 }


### PR DESCRIPTION
- Bump .NET SDK from 5.0.100 to 5.0.102.
- Bump cake.tool to RC2.
- Fix warnings.
- Fix AppVeyor Mac OS .NET SDK install path.