### PR TITLE
Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,7 +23,7 @@
   <ItemGroup Label="Package References">
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="16.8.55" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="2.4.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.1.118" />
+    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.321" />
   </ItemGroup>
 
 </Project>

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "1.0.0-rc0002",
+      "version": "1.0.0-rc0003",
       "commands": [
         "dotnet-cake"
       ]


### PR DESCRIPTION
- Bump StyleCop.Analyzers from 1.1.118 to 1.2.0-beta.321, this allows use of new C# features without warnings.
- Bump dotnet-cake from 1.0.0-rc0002 to 1.0.0-rc0003.