### PR TITLE
Reduce allocation for single Activity

### DIFF
--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -9,7 +9,16 @@ namespace Serilog.Enrichers.Span
     /// </summary>
     public class ActivityEnricher : ILogEventEnricher
     {
-#if NET5_0
+        private const string SpanId = "SpanId";
+        private const string TraceId = "TraceId";
+        private const string ParentId = "ParentId";
+
+#if NET5_0_OR_GREATER
+
+        private const string SpanIdKey = "Serilog.SpanId";
+        private const string TraceIdKey = "Serilog.TraceId";
+        private const string ParentIdKey = "Serilog.ParentId";
+
         /// <summary>
         /// Enrich the log event.
         /// </summary>
@@ -29,11 +38,11 @@ namespace Serilog.Enrichers.Span
 
         private static void AddSpanId(LogEvent logEvent, Activity activity)
         {
-            var property = activity.GetCustomProperty("Serilog.SpanId");
+            var property = activity.GetCustomProperty(SpanIdKey);
             if (property is null || property is not LogEventProperty logEventProperty)
             {
-                logEventProperty = new LogEventProperty("SpanId", new ScalarValue(activity.GetSpanId()));
-                activity.SetCustomProperty("Serilog.SpanId", logEventProperty);
+                logEventProperty = new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId()));
+                activity.SetCustomProperty(SpanIdKey, logEventProperty);
             }
 
             logEvent.AddPropertyIfAbsent(logEventProperty);
@@ -41,11 +50,11 @@ namespace Serilog.Enrichers.Span
 
         private static void AddTraceId(LogEvent logEvent, Activity activity)
         {
-            var property = activity.GetCustomProperty("Serilog.TraceId");
+            var property = activity.GetCustomProperty(TraceIdKey);
             if (property is null || property is not LogEventProperty logEventProperty)
             {
-                logEventProperty = new LogEventProperty("TraceId", new ScalarValue(activity.GetTraceId()));
-                activity.SetCustomProperty("Serilog.TraceId", logEventProperty);
+                logEventProperty = new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId()));
+                activity.SetCustomProperty(TraceIdKey, logEventProperty);
             }
 
             logEvent.AddPropertyIfAbsent(logEventProperty);
@@ -53,16 +62,17 @@ namespace Serilog.Enrichers.Span
 
         private static void AddParentId(LogEvent logEvent, Activity activity)
         {
-            var property = activity.GetCustomProperty("Serilog.ParentId");
+            var property = activity.GetCustomProperty(ParentIdKey);
             if (property is null || property is not LogEventProperty logEventProperty)
             {
-                logEventProperty = new LogEventProperty("ParentId", new ScalarValue(activity.GetParentId()));
-                activity.SetCustomProperty("Serilog.ParentId", logEventProperty);
+                logEventProperty = new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId()));
+                activity.SetCustomProperty(ParentIdKey, logEventProperty);
             }
 
             logEvent.AddPropertyIfAbsent(logEventProperty);
         }
-#elif NETCOREAPP3_0 || NETCOREAPP3_1
+#else
+
         /// <summary>
         /// Enrich the log event.
         /// </summary>
@@ -74,9 +84,9 @@ namespace Serilog.Enrichers.Span
 
             if (activity is not null)
             {
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("SpanId", new ScalarValue(activity.GetSpanId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("TraceId", new ScalarValue(activity.GetTraceId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("ParentId", new ScalarValue(activity.GetParentId())));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId())));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId())));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId())));
             }
         }
 #endif

--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -9,6 +9,7 @@ namespace Serilog.Enrichers.Span
     /// </summary>
     public class ActivityEnricher : ILogEventEnricher
     {
+#if NET5_0
         /// <summary>
         /// Enrich the log event.
         /// </summary>
@@ -25,7 +26,7 @@ namespace Serilog.Enrichers.Span
                 AddParentId(logEvent, activity);
             }
         }
-        
+
         private static void AddSpanId(LogEvent logEvent, Activity activity)
         {
             var property = activity.GetCustomProperty("Serilog.SpanId");
@@ -61,5 +62,23 @@ namespace Serilog.Enrichers.Span
 
             logEvent.AddPropertyIfAbsent(logEventProperty);
         }
+#elif NETCOREAPP3_0 || NETCOREAPP3_1
+        /// <summary>
+        /// Enrich the log event.
+        /// </summary>
+        /// <param name="logEvent">The log event to enrich.</param>
+        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {
+            var activity = Activity.Current;
+
+            if (activity is not null)
+            {
+                logEvent.AddPropertyIfAbsent(new LogEventProperty("SpanId", new ScalarValue(activity.GetSpanId())));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty("TraceId", new ScalarValue(activity.GetTraceId())));
+                logEvent.AddPropertyIfAbsent(new LogEventProperty("ParentId", new ScalarValue(activity.GetParentId())));
+            }
+        }
+#endif
     }
 }

--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -20,10 +20,46 @@ namespace Serilog.Enrichers.Span
 
             if (activity is not null)
             {
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("SpanId", new ScalarValue(activity.GetSpanId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("TraceId", new ScalarValue(activity.GetTraceId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty("ParentId", new ScalarValue(activity.GetParentId())));
+                AddSpanId(logEvent, activity);
+                AddTraceId(logEvent, activity);
+                AddParentId(logEvent, activity);
             }
+        }
+        
+        private static void AddSpanId(LogEvent logEvent, Activity activity)
+        {
+            var property = activity.GetCustomProperty("Serilog.SpanId");
+            if (property is null || property is not LogEventProperty logEventProperty)
+            {
+                logEventProperty = new LogEventProperty("SpanId", new ScalarValue(activity.GetSpanId()));
+                activity.SetCustomProperty("Serilog.SpanId", logEventProperty);
+            }
+
+            logEvent.AddPropertyIfAbsent(logEventProperty);
+        }
+
+        private static void AddTraceId(LogEvent logEvent, Activity activity)
+        {
+            var property = activity.GetCustomProperty("Serilog.TraceId");
+            if (property is null || property is not LogEventProperty logEventProperty)
+            {
+                logEventProperty = new LogEventProperty("TraceId", new ScalarValue(activity.GetTraceId()));
+                activity.SetCustomProperty("Serilog.TraceId", logEventProperty);
+            }
+
+            logEvent.AddPropertyIfAbsent(logEventProperty);
+        }
+
+        private static void AddParentId(LogEvent logEvent, Activity activity)
+        {
+            var property = activity.GetCustomProperty("Serilog.ParentId");
+            if (property is null || property is not LogEventProperty logEventProperty)
+            {
+                logEventProperty = new LogEventProperty("ParentId", new ScalarValue(activity.GetParentId()));
+                activity.SetCustomProperty("Serilog.ParentId", logEventProperty);
+            }
+
+            logEvent.AddPropertyIfAbsent(logEventProperty);
         }
     }
 }


### PR DESCRIPTION
Hi!

What do you think about storing the `LogEventProperty` in the Activity instead of creating them on each log event to reduce allocation?

