### PR TITLE
Support Framework 472

### DIFF
--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -12,6 +12,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.1" Condition="'$(TargetFramework)' == 'net472'" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added support for .net framework 4.7.2. This required adding a reference to the Microsoft diagnostics activity source package which is only included for net 4.7.2

https://github.com/RehanSaeed/Serilog.Enrichers.Span/issues/70