### PR TITLE
Add .NET 6 and C# 10 Support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-# Version: 3.0.0 (Using https://semver.org/)
-# Updated: 2021-08-09
+# Version: 4.0.0 (Using https://semver.org/)
+# Updated: 2021-10-12
 # See https://github.com/RehanSaeed/EditorConfig/releases for release notes.
 # See https://github.com/RehanSaeed/EditorConfig for updates to this file.
 # See http://EditorConfig.org for more information about .editorconfig files.

--- a/.editorconfig
+++ b/.editorconfig
@@ -167,6 +167,8 @@ dotnet_diagnostic.IDE0063.severity = suggestion
 csharp_using_directive_placement = inside_namespace:warning
 # Modifier preferences
 csharp_prefer_static_local_function = true:warning
+# Undocumented
+csharp_style_namespace_declarations = file_scoped:warning
 
 ##########################################
 # Unnecessary Code Rules

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - name: "Install .NET Core 3.1 SDK"
-        uses: actions/setup-dotnet@v1.8.2
-        with:
-          dotnet-version: "3.1.x"
-      - name: "Install .NET Core 5.0 SDK"
-        uses: actions/setup-dotnet@v1.8.2
-        with:
-          dotnet-version: "5.0.x"
+      #- name: "Install .NET Core 3.1 SDK"
+      #  uses: actions/setup-dotnet@v1.8.2
+      #  with:
+      #    dotnet-version: "3.1.x"
+      #- name: "Install .NET Core 5.0 SDK"
+      #  uses: actions/setup-dotnet@v1.8.2
+      #  with:
+      #    dotnet-version: "5.0.x"
       - name: "Install .NET SDK"
         uses: actions/setup-dotnet@v1.8.2
       - name: "Dotnet Tool Restore"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,14 +33,14 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      #- name: "Install .NET Core 3.1 SDK"
-      #  uses: actions/setup-dotnet@v1.8.2
-      #  with:
-      #    dotnet-version: "3.1.x"
-      #- name: "Install .NET Core 5.0 SDK"
-      #  uses: actions/setup-dotnet@v1.8.2
-      #  with:
-      #    dotnet-version: "5.0.x"
+      - name: "Install .NET Core 3.1 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "3.1.x"
+      - name: "Install .NET Core 5.0 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "5.0.x"
       - name: "Install .NET SDK"
         uses: actions/setup-dotnet@v1.8.2
       - name: "Dotnet Tool Restore"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,15 @@ jobs:
         with:
           lfs: true
           fetch-depth: 0
-      - name: "Install .NET Core SDK"
+      - name: "Install .NET Core 3.1 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "3.1.x"
+      - name: "Install .NET Core 5.0 SDK"
+        uses: actions/setup-dotnet@v1.8.2
+        with:
+          dotnet-version: "5.0.x"
+      - name: "Install .NET SDK"
         uses: actions/setup-dotnet@v1.8.2
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/RehanSaeed/Serilog.Enrichers.Span</PackageProjectUrl>
     <PackageIcon>Icon.png</PackageIcon>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/RehanSaeed/Serilog.Enrichers.Span.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes>https://github.com/RehanSaeed/Serilog.Enrichers.Span/releases</PackageReleaseNotes>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Banner](Images/Banner.png)
+![Banner](https://media.githubusercontent.com/media/RehanSaeed/Serilog.Enrichers.Span/main/Images/Banner.png)
 
 [![Serilog.Enrichers.Span NuGet Package](https://img.shields.io/nuget/v/Serilog.Enrichers.Span.svg)](https://www.nuget.org/packages/Serilog.Enrichers.Span/) [![Serilog.Enrichers.Span package in serilog-exceptions feed in Azure Artifacts](https://feeds.dev.azure.com/serilog-exceptions/_apis/public/Packaging/Feeds/8479813c-da6b-4677-b40d-78df8725dc9c/Packages/3f8a2a7e-8124-4987-9c44-916dba83b9d6/Badge)](https://dev.azure.com/serilog-exceptions/Serilog.Enrichers.Span/_packaging?_a=package&feed=8479813c-da6b-4677-b40d-78df8725dc9c&package=3f8a2a7e-8124-4987-9c44-916dba83b9d6&preferRelease=true) [![Serilog.Enrichers.Span NuGet Package Downloads](https://img.shields.io/nuget/dt/Serilog.Enrichers.Span)](https://www.nuget.org/packages/Serilog.Enrichers.Span) [![Twitter URL](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/RehanSaeedUK) [![Twitter Follow](https://img.shields.io/twitter/follow/rehansaeeduk.svg?style=social&label=Follow)](https://twitter.com/RehanSaeedUK)
 
@@ -43,4 +43,4 @@ ILogger logger = new LoggerConfiguration()
 
 ## Contributions and Thanks
 
-Please view the [contributing guide](/.github/CONTRIBUTING.md) for more information.
+Please view the [contributing guide](https://github.com/RehanSaeed/Serilog.Enrichers.Span/blob/main/.github/CONTRIBUTING.md) for more information.

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -27,6 +27,7 @@
 
   <ItemGroup Label="Files">
     <None Include="..\..\Images\Icon.png" Pack="true" PackagePath="\" />
+    <None Include="..\..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -26,10 +26,7 @@ public class ActivityEnricher : ILogEventEnricher
     /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        if (logEvent == null)
-        {
-            throw new ArgumentNullException(nameof(logEvent));
-        }
+        ArgumentNullException.ThrowIfNull(logEvent);
 
         var activity = Activity.Current;
 

--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -26,7 +26,14 @@ public class ActivityEnricher : ILogEventEnricher
     /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(logEvent);
+#else
+        if (logEvent is null)
+        {
+            throw new ArgumentNullException(nameof(logEvent));
+        }
+#endif
 
         var activity = Activity.Current;
 

--- a/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityEnricher.cs
@@ -1,88 +1,87 @@
-namespace Serilog.Enrichers.Span
+namespace Serilog.Enrichers.Span;
+
+using System;
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// A log event enricher which adds span information from the current <see cref="Activity"/>.
+/// </summary>
+public class ActivityEnricher : ILogEventEnricher
 {
-    using System;
-    using System.Diagnostics;
-    using Serilog.Core;
-    using Serilog.Events;
+    private const string SpanId = "SpanId";
+    private const string TraceId = "TraceId";
+    private const string ParentId = "ParentId";
+#if NET5_0_OR_GREATER
+    private const string SpanIdKey = "Serilog.SpanId";
+    private const string TraceIdKey = "Serilog.TraceId";
+    private const string ParentIdKey = "Serilog.ParentId";
+#endif
 
     /// <summary>
-    /// A log event enricher which adds span information from the current <see cref="Activity"/>.
+    /// Enrich the log event.
     /// </summary>
-    public class ActivityEnricher : ILogEventEnricher
+    /// <param name="logEvent">The log event to enrich.</param>
+    /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        private const string SpanId = "SpanId";
-        private const string TraceId = "TraceId";
-        private const string ParentId = "ParentId";
-#if NET5_0_OR_GREATER
-        private const string SpanIdKey = "Serilog.SpanId";
-        private const string TraceIdKey = "Serilog.TraceId";
-        private const string ParentIdKey = "Serilog.ParentId";
-#endif
-
-        /// <summary>
-        /// Enrich the log event.
-        /// </summary>
-        /// <param name="logEvent">The log event to enrich.</param>
-        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        if (logEvent == null)
         {
-            if (logEvent == null)
-            {
-                throw new ArgumentNullException(nameof(logEvent));
-            }
+            throw new ArgumentNullException(nameof(logEvent));
+        }
 
-            var activity = Activity.Current;
+        var activity = Activity.Current;
 
-            if (activity is not null)
-            {
+        if (activity is not null)
+        {
 #if NET5_0_OR_GREATER
-                AddSpanId(logEvent, activity);
-                AddTraceId(logEvent, activity);
-                AddParentId(logEvent, activity);
+            AddSpanId(logEvent, activity);
+            AddTraceId(logEvent, activity);
+            AddParentId(logEvent, activity);
 #else
-                logEvent.AddPropertyIfAbsent(new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId())));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId())));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId())));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId())));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId())));
 #endif
-            }
         }
+    }
 #if NET5_0_OR_GREATER
 
-        private static void AddSpanId(LogEvent logEvent, Activity activity)
+    private static void AddSpanId(LogEvent logEvent, Activity activity)
+    {
+        var property = activity.GetCustomProperty(SpanIdKey);
+        if (property is null || property is not LogEventProperty logEventProperty)
         {
-            var property = activity.GetCustomProperty(SpanIdKey);
-            if (property is null || property is not LogEventProperty logEventProperty)
-            {
-                logEventProperty = new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId()));
-                activity.SetCustomProperty(SpanIdKey, logEventProperty);
-            }
-
-            logEvent.AddPropertyIfAbsent(logEventProperty);
+            logEventProperty = new LogEventProperty(SpanId, new ScalarValue(activity.GetSpanId()));
+            activity.SetCustomProperty(SpanIdKey, logEventProperty);
         }
 
-        private static void AddTraceId(LogEvent logEvent, Activity activity)
-        {
-            var property = activity.GetCustomProperty(TraceIdKey);
-            if (property is null || property is not LogEventProperty logEventProperty)
-            {
-                logEventProperty = new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId()));
-                activity.SetCustomProperty(TraceIdKey, logEventProperty);
-            }
-
-            logEvent.AddPropertyIfAbsent(logEventProperty);
-        }
-
-        private static void AddParentId(LogEvent logEvent, Activity activity)
-        {
-            var property = activity.GetCustomProperty(ParentIdKey);
-            if (property is null || property is not LogEventProperty logEventProperty)
-            {
-                logEventProperty = new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId()));
-                activity.SetCustomProperty(ParentIdKey, logEventProperty);
-            }
-
-            logEvent.AddPropertyIfAbsent(logEventProperty);
-        }
-#endif
+        logEvent.AddPropertyIfAbsent(logEventProperty);
     }
+
+    private static void AddTraceId(LogEvent logEvent, Activity activity)
+    {
+        var property = activity.GetCustomProperty(TraceIdKey);
+        if (property is null || property is not LogEventProperty logEventProperty)
+        {
+            logEventProperty = new LogEventProperty(TraceId, new ScalarValue(activity.GetTraceId()));
+            activity.SetCustomProperty(TraceIdKey, logEventProperty);
+        }
+
+        logEvent.AddPropertyIfAbsent(logEventProperty);
+    }
+
+    private static void AddParentId(LogEvent logEvent, Activity activity)
+    {
+        var property = activity.GetCustomProperty(ParentIdKey);
+        if (property is null || property is not LogEventProperty logEventProperty)
+        {
+            logEventProperty = new LogEventProperty(ParentId, new ScalarValue(activity.GetParentId()));
+            activity.SetCustomProperty(ParentIdKey, logEventProperty);
+        }
+
+        logEvent.AddPropertyIfAbsent(logEventProperty);
+    }
+#endif
 }

--- a/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
@@ -1,5 +1,6 @@
 namespace Serilog.Enrichers.Span;
 
+using System;
 using System.Diagnostics;
 
 /// <summary>
@@ -14,6 +15,8 @@ internal static class ActivityExtensions
     /// <returns>The span unique identifier.</returns>
     public static string GetSpanId(this Activity activity)
     {
+        ArgumentNullException.ThrowIfNull(activity);
+
         var spanId = activity.IdFormat switch
         {
             ActivityIdFormat.Hierarchical => activity.Id,
@@ -32,6 +35,8 @@ internal static class ActivityExtensions
     /// <returns>The span trace unique identifier.</returns>
     public static string GetTraceId(this Activity activity)
     {
+        ArgumentNullException.ThrowIfNull(activity);
+
         var traceId = activity.IdFormat switch
         {
             ActivityIdFormat.Hierarchical => activity.RootId,
@@ -50,6 +55,8 @@ internal static class ActivityExtensions
     /// <returns>The span parent unique identifier.</returns>
     public static string GetParentId(this Activity activity)
     {
+        ArgumentNullException.ThrowIfNull(activity);
+
         var parentId = activity.IdFormat switch
         {
             ActivityIdFormat.Hierarchical => activity.ParentId,

--- a/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
@@ -1,64 +1,63 @@
-namespace Serilog.Enrichers.Span
+namespace Serilog.Enrichers.Span;
+
+using System.Diagnostics;
+
+/// <summary>
+/// <see cref="Activity"/> extension methods.
+/// </summary>
+internal static class ActivityExtensions
 {
-    using System.Diagnostics;
+    /// <summary>
+    /// Gets the span unique identifier regardless of the activity identifier format.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns>The span unique identifier.</returns>
+    public static string GetSpanId(this Activity activity)
+    {
+        var spanId = activity.IdFormat switch
+        {
+            ActivityIdFormat.Hierarchical => activity.Id,
+            ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
+
+        return spanId ?? string.Empty;
+    }
 
     /// <summary>
-    /// <see cref="Activity"/> extension methods.
+    /// Gets the span trace unique identifier regardless of the activity identifier format.
     /// </summary>
-    internal static class ActivityExtensions
+    /// <param name="activity">The activity.</param>
+    /// <returns>The span trace unique identifier.</returns>
+    public static string GetTraceId(this Activity activity)
     {
-        /// <summary>
-        /// Gets the span unique identifier regardless of the activity identifier format.
-        /// </summary>
-        /// <param name="activity">The activity.</param>
-        /// <returns>The span unique identifier.</returns>
-        public static string GetSpanId(this Activity activity)
+        var traceId = activity.IdFormat switch
         {
-            var spanId = activity.IdFormat switch
-            {
-                ActivityIdFormat.Hierarchical => activity.Id,
-                ActivityIdFormat.W3C => activity.SpanId.ToHexString(),
-                ActivityIdFormat.Unknown => null,
-                _ => null,
-            };
+            ActivityIdFormat.Hierarchical => activity.RootId,
+            ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
 
-            return spanId ?? string.Empty;
-        }
+        return traceId ?? string.Empty;
+    }
 
-        /// <summary>
-        /// Gets the span trace unique identifier regardless of the activity identifier format.
-        /// </summary>
-        /// <param name="activity">The activity.</param>
-        /// <returns>The span trace unique identifier.</returns>
-        public static string GetTraceId(this Activity activity)
+    /// <summary>
+    /// Gets the span parent unique identifier regardless of the activity identifier format.
+    /// </summary>
+    /// <param name="activity">The activity.</param>
+    /// <returns>The span parent unique identifier.</returns>
+    public static string GetParentId(this Activity activity)
+    {
+        var parentId = activity.IdFormat switch
         {
-            var traceId = activity.IdFormat switch
-            {
-                ActivityIdFormat.Hierarchical => activity.RootId,
-                ActivityIdFormat.W3C => activity.TraceId.ToHexString(),
-                ActivityIdFormat.Unknown => null,
-                _ => null,
-            };
+            ActivityIdFormat.Hierarchical => activity.ParentId,
+            ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
+            ActivityIdFormat.Unknown => null,
+            _ => null,
+        };
 
-            return traceId ?? string.Empty;
-        }
-
-        /// <summary>
-        /// Gets the span parent unique identifier regardless of the activity identifier format.
-        /// </summary>
-        /// <param name="activity">The activity.</param>
-        /// <returns>The span parent unique identifier.</returns>
-        public static string GetParentId(this Activity activity)
-        {
-            var parentId = activity.IdFormat switch
-            {
-                ActivityIdFormat.Hierarchical => activity.ParentId,
-                ActivityIdFormat.W3C => activity.ParentSpanId.ToHexString(),
-                ActivityIdFormat.Unknown => null,
-                _ => null,
-            };
-
-            return parentId ?? string.Empty;
-        }
+        return parentId ?? string.Empty;
     }
 }

--- a/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
@@ -15,7 +15,14 @@ internal static class ActivityExtensions
     /// <returns>The span unique identifier.</returns>
     public static string GetSpanId(this Activity activity)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(activity);
+#else
+        if (activity is null)
+{
+            throw new ArgumentNullException(nameof(activity));
+        }
+#endif
 
         var spanId = activity.IdFormat switch
         {
@@ -35,7 +42,14 @@ internal static class ActivityExtensions
     /// <returns>The span trace unique identifier.</returns>
     public static string GetTraceId(this Activity activity)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(activity);
+#else
+        if (activity is null)
+        {
+            throw new ArgumentNullException(nameof(activity));
+        }
+#endif
 
         var traceId = activity.IdFormat switch
         {
@@ -55,7 +69,14 @@ internal static class ActivityExtensions
     /// <returns>The span parent unique identifier.</returns>
     public static string GetParentId(this Activity activity)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(activity);
+#else
+        if (activity is null)
+        {
+            throw new ArgumentNullException(nameof(activity));
+        }
+#endif
 
         var parentId = activity.IdFormat switch
         {

--- a/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityExtensions.cs
@@ -19,7 +19,7 @@ internal static class ActivityExtensions
         ArgumentNullException.ThrowIfNull(activity);
 #else
         if (activity is null)
-{
+        {
             throw new ArgumentNullException(nameof(activity));
         }
 #endif

--- a/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
@@ -20,13 +20,9 @@ public class ActivityTagEnricher : ILogEventEnricher
     /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        if (logEvent == null)
-        {
-            throw new ArgumentNullException(nameof(logEvent));
-        }
+        ArgumentNullException.ThrowIfNull(logEvent);
 
         var activity = Activity.Current;
-
         if (activity is not null)
         {
             var tags = activity.Tags.Select(tag => new LogEventProperty(tag.Key, new ScalarValue(tag.Value)));

--- a/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
@@ -20,7 +20,14 @@ public class ActivityTagEnricher : ILogEventEnricher
     /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
     public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(logEvent);
+#else
+        if (logEvent is null)
+        {
+            throw new ArgumentNullException(nameof(logEvent));
+        }
+#endif
 
         var activity = Activity.Current;
         if (activity is not null)

--- a/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
@@ -1,37 +1,36 @@
-namespace Serilog.Enrichers.Span
+namespace Serilog.Enrichers.Span;
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// A log event enricher which adds tags from the current <see cref="Activity"/>.
+/// </summary>
+public class ActivityTagEnricher : ILogEventEnricher
 {
-    using System;
-    using System.Diagnostics;
-    using System.Linq;
-    using Serilog.Core;
-    using Serilog.Events;
+    private const string ActivityTags = "Attributes";
 
     /// <summary>
-    /// A log event enricher which adds tags from the current <see cref="Activity"/>.
+    /// Enrich the log event.
     /// </summary>
-    public class ActivityTagEnricher : ILogEventEnricher
+    /// <param name="logEvent">The log event to enrich.</param>
+    /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
     {
-        private const string ActivityTags = "Attributes";
-
-        /// <summary>
-        /// Enrich the log event.
-        /// </summary>
-        /// <param name="logEvent">The log event to enrich.</param>
-        /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
-        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        if (logEvent == null)
         {
-            if (logEvent == null)
-            {
-                throw new ArgumentNullException(nameof(logEvent));
-            }
+            throw new ArgumentNullException(nameof(logEvent));
+        }
 
-            var activity = Activity.Current;
+        var activity = Activity.Current;
 
-            if (activity is not null)
-            {
-                var tags = activity.Tags.Select(tag => new LogEventProperty(tag.Key, new ScalarValue(tag.Value)));
-                logEvent.AddPropertyIfAbsent(new LogEventProperty(ActivityTags, new StructureValue(tags)));
-            }
+        if (activity is not null)
+        {
+            var tags = activity.Tags.Select(tag => new LogEventProperty(tag.Key, new ScalarValue(tag.Value)));
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(ActivityTags, new StructureValue(tags)));
         }
     }
 }

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -14,8 +14,8 @@ public static class LoggerEnrichmentConfigurationExtensions
     /// </summary>
     /// <param name="loggerEnrichmentConfiguration">The enrichment configuration.</param>
     /// <returns>Configuration object allowing method chaining.</returns>
-    public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-        => loggerEnrichmentConfiguration.WithSpan(new SpanOptions());
+    public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration) =>
+        loggerEnrichmentConfiguration.WithSpan(new SpanOptions());
 
     /// <summary>
     /// Enrich logger output with span information from the current <see cref="Activity"/>.
@@ -25,15 +25,8 @@ public static class LoggerEnrichmentConfigurationExtensions
     /// <returns>Configuration object allowing method chaining.</returns>
     public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, SpanOptions spanOptions)
     {
-        if (loggerEnrichmentConfiguration is null)
-        {
-            throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
-        }
-
-        if (spanOptions is null)
-        {
-            throw new ArgumentNullException(nameof(spanOptions));
-        }
+        ArgumentNullException.ThrowIfNull(loggerEnrichmentConfiguration);
+        ArgumentNullException.ThrowIfNull(spanOptions);
 
         if (spanOptions.IncludeTags)
         {

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -1,46 +1,45 @@
-namespace Serilog.Enrichers.Span
+namespace Serilog.Enrichers.Span;
+
+using System;
+using System.Diagnostics;
+using Serilog.Configuration;
+
+/// <summary>
+/// <see cref="LoggerEnrichmentConfiguration"/> extension methods.
+/// </summary>
+public static class LoggerEnrichmentConfigurationExtensions
 {
-    using System;
-    using System.Diagnostics;
-    using Serilog.Configuration;
+    /// <summary>
+    /// Enrich logger output with span information from the current <see cref="Activity"/>.
+    /// </summary>
+    /// <param name="loggerEnrichmentConfiguration">The enrichment configuration.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+        => loggerEnrichmentConfiguration.WithSpan(new SpanOptions());
 
     /// <summary>
-    /// <see cref="LoggerEnrichmentConfiguration"/> extension methods.
+    /// Enrich logger output with span information from the current <see cref="Activity"/>.
     /// </summary>
-    public static class LoggerEnrichmentConfigurationExtensions
+    /// <param name="loggerEnrichmentConfiguration">The enrichment configuration.</param>
+    /// <param name="spanOptions"><see cref="SpanOptions"/> to use for enriching Activity.</param>
+    /// <returns>Configuration object allowing method chaining.</returns>
+    public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, SpanOptions spanOptions)
     {
-        /// <summary>
-        /// Enrich logger output with span information from the current <see cref="Activity"/>.
-        /// </summary>
-        /// <param name="loggerEnrichmentConfiguration">The enrichment configuration.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-            => loggerEnrichmentConfiguration.WithSpan(new SpanOptions());
-
-        /// <summary>
-        /// Enrich logger output with span information from the current <see cref="Activity"/>.
-        /// </summary>
-        /// <param name="loggerEnrichmentConfiguration">The enrichment configuration.</param>
-        /// <param name="spanOptions"><see cref="SpanOptions"/> to use for enriching Activity.</param>
-        /// <returns>Configuration object allowing method chaining.</returns>
-        public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, SpanOptions spanOptions)
+        if (loggerEnrichmentConfiguration is null)
         {
-            if (loggerEnrichmentConfiguration is null)
-            {
-                throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
-            }
-
-            if (spanOptions is null)
-            {
-                throw new ArgumentNullException(nameof(spanOptions));
-            }
-
-            if (spanOptions.IncludeTags)
-            {
-                loggerEnrichmentConfiguration.With<ActivityTagEnricher>();
-            }
-
-            return loggerEnrichmentConfiguration.With<ActivityEnricher>();
+            throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
         }
+
+        if (spanOptions is null)
+        {
+            throw new ArgumentNullException(nameof(spanOptions));
+        }
+
+        if (spanOptions.IncludeTags)
+        {
+            loggerEnrichmentConfiguration.With<ActivityTagEnricher>();
+        }
+
+        return loggerEnrichmentConfiguration.With<ActivityEnricher>();
     }
 }

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -25,8 +25,20 @@ public static class LoggerEnrichmentConfigurationExtensions
     /// <returns>Configuration object allowing method chaining.</returns>
     public static LoggerConfiguration WithSpan(this LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, SpanOptions spanOptions)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(loggerEnrichmentConfiguration);
         ArgumentNullException.ThrowIfNull(spanOptions);
+#else
+        if (loggerEnrichmentConfiguration is null)
+        {
+            throw new ArgumentNullException(nameof(loggerEnrichmentConfiguration));
+        }
+
+        if (spanOptions is null)
+        {
+            throw new ArgumentNullException(nameof(spanOptions));
+        }
+#endif
 
         if (spanOptions.IncludeTags)
         {

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -12,6 +12,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup Label="Package References (.NET 4.7.2)" Condition="'$(TargetFramework)' == 'net472'">

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net472</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Enrichers.Span/SpanOptions.cs
+++ b/Source/Serilog.Enrichers.Span/SpanOptions.cs
@@ -1,13 +1,12 @@
-namespace Serilog.Enrichers.Span
+namespace Serilog.Enrichers.Span;
+
+/// <summary>
+/// Options.
+/// </summary>
+public class SpanOptions
 {
     /// <summary>
-    /// Options.
+    /// Gets or sets a value indicating whether to include tags in log or not. Default is false.
     /// </summary>
-    public class SpanOptions
-    {
-        /// <summary>
-        /// Gets or sets a value indicating whether to include tags in log or not. Default is false.
-        /// </summary>
-        public bool IncludeTags { get; set; }
-    }
+    public bool IncludeTags { get; set; }
 }

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -8,6 +8,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.CodeCoverage" PrivateAssets="All" Version="17.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.0.0" />
     <PackageReference Include="Moq" Version="4.16.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" Version="2.4.3">

--- a/Tests/Serilog.Enrichers.Span.Test/Class1Test.cs
+++ b/Tests/Serilog.Enrichers.Span.Test/Class1Test.cs
@@ -1,16 +1,15 @@
-namespace Serilog.Enrichers.Span.Test
+namespace Serilog.Enrichers.Span.Test;
+
+using Serilog.Enrichers.Span;
+using Xunit;
+
+public class Class1Test
 {
-    using Serilog.Enrichers.Span;
-    using Xunit;
-
-    public class Class1Test
+    [Fact]
+    public void Given_When_Then()
     {
-        [Fact]
-        public void Given_When_Then()
-        {
-            var class1 = new ActivityEnricher();
+        var class1 = new ActivityEnricher();
 
-            Assert.NotNull(class1);
-        }
+        Assert.NotNull(class1);
     }
 }

--- a/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
+++ b/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
+++ b/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
+++ b/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,16 +43,16 @@ stages:
         steps:
           - checkout: self
             lfs: true
-          - task: UseDotNet@2
-            displayName: "Install .NET Core 3.1 SDK"
-            inputs:
-              packageType: "sdk"
-              version: 3.1.x
-          - task: UseDotNet@2
-            displayName: "Install .NET Core 5.0 SDK"
-            inputs:
-              packageType: "sdk"
-              version: 5.0.x
+          #- task: UseDotNet@2
+          #  displayName: "Install .NET Core 3.1 SDK"
+          #  inputs:
+          #    packageType: "sdk"
+          #    version: 3.1.x
+          #- task: UseDotNet@2
+          #  displayName: "Install .NET Core 5.0 SDK"
+          #  inputs:
+          #    packageType: "sdk"
+          #    version: 5.0.x
           - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,16 +43,16 @@ stages:
         steps:
           - checkout: self
             lfs: true
-          #- task: UseDotNet@2
-          #  displayName: "Install .NET Core 3.1 SDK"
-          #  inputs:
-          #    packageType: "sdk"
-          #    version: 3.1.x
-          #- task: UseDotNet@2
-          #  displayName: "Install .NET Core 5.0 SDK"
-          #  inputs:
-          #    packageType: "sdk"
-          #    version: 5.0.x
+          - task: UseDotNet@2
+            displayName: "Install .NET Core 3.1 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 3.1.x
+          - task: UseDotNet@2
+            displayName: "Install .NET Core 5.0 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 5.0.x
           - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,16 @@ stages:
           - checkout: self
             lfs: true
           - task: UseDotNet@2
+            displayName: "Install .NET Core 3.1 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 3.1.x
+          - task: UseDotNet@2
+            displayName: "Install .NET Core 5.0 SDK"
+            inputs:
+              packageType: "sdk"
+              version: 5.0.x
+          - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:
               packageType: "sdk"

--- a/global.json
+++ b/global.json
@@ -1,6 +1,7 @@
 {
   "sdk": {
+    "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "5.0.401"
+    "version": "6.0.100-rc.1.21463.6"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.100-rc.1.21463.6"
+    "version": "6.0.100-rc.2.21505.57"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.100-rc.2.21505.57"
+    "version": "6.0.100"
   }
 }


### PR DESCRIPTION
- Add .NET 6 target framework.
- Use `ArgumentNullException.ThrowIfNull` where available.
- Will update the `.editorconfig` in a later PR and go with file scoped namespaces.
- Add embedded `README.md` to NuGet packages (https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packagereadmefile).