### PR TITLE
Added ability to log baggage items just like tags

### DIFF
--- a/Source/Serilog.Enrichers.Span/ActivityBaggageEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityBaggageEnricher.cs
@@ -1,0 +1,42 @@
+namespace Serilog.Enrichers.Span;
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// A log event enricher which adds baggage from the current <see cref="Activity"/>.
+/// </summary>
+public class ActivityBaggageEnricher : ILogEventEnricher
+{
+    private const string BaggageTags = "Baggage";
+
+    /// <summary>
+    /// Enrich the log event.
+    /// </summary>
+    /// <param name="logEvent">The log event to enrich.</param>
+    /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(logEvent);
+#else
+        if (logEvent is null)
+        {
+            throw new ArgumentNullException(nameof(logEvent));
+        }
+#endif
+
+        var activity = Activity.Current;
+        if (activity is not null)
+        {
+            var baggage = activity.Baggage.Select(bag => new LogEventProperty(bag.Key, new ScalarValue(bag.Value)));
+            if (baggage.Any())
+            {
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(BaggageTags, new StructureValue(baggage)));
+            }
+        }
+    }
+}

--- a/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityTagEnricher.cs
@@ -33,7 +33,10 @@ public class ActivityTagEnricher : ILogEventEnricher
         if (activity is not null)
         {
             var tags = activity.Tags.Select(tag => new LogEventProperty(tag.Key, new ScalarValue(tag.Value)));
-            logEvent.AddPropertyIfAbsent(new LogEventProperty(ActivityTags, new StructureValue(tags)));
+            if (tags.Any())
+            {
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(ActivityTags, new StructureValue(tags)));
+            }
         }
     }
 }

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -47,6 +47,11 @@ public static class LoggerEnrichmentConfigurationExtensions
             loggerEnrichmentConfiguration.With<ActivityTagEnricher>();
         }
 
+        if (spanOptions.IncludeBaggage)
+        {
+            loggerEnrichmentConfiguration.With<ActivityBaggageEnricher>();
+        }
+
         return loggerEnrichmentConfiguration.With(new ActivityEnricher(spanOptions.LogEventPropertiesNames));
     }
 }

--- a/Source/Serilog.Enrichers.Span/SpanOptions.cs
+++ b/Source/Serilog.Enrichers.Span/SpanOptions.cs
@@ -11,6 +11,11 @@ public class SpanOptions
     public bool IncludeTags { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include baggage in log or not. Default is false.
+    /// </summary>
+    public bool IncludeBaggage { get; set; }
+
+    /// <summary>
     /// Gets or sets log properties names for span.
     /// </summary>
     public SpanLogEventPropertiesNames LogEventPropertiesNames { get; set; } = new();


### PR DESCRIPTION
Added an option to control if baggage items should be logged using `SpanOptions.IncludeBaggage`.
The default value is `false` just like for `IncludeTags`.