### PR TITLE
Upgrade to .NET 7 and C# 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           dotnet-version: |
             3.1.x
-            5.0.x
+            6.0.x
           global-json-file: "./global.json"
       - name: "Dotnet Tool Restore"
         run: dotnet tool restore

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,6 @@ jobs:
         uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
-            3.1.x
             6.0.x
           global-json-file: "./global.json"
       - name: "Dotnet Tool Restore"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           lfs: true
           fetch-depth: 0
       - name: "Install .NET SDK"
-        uses: actions/setup-dotnet@v3.0.2
+        uses: actions/setup-dotnet@v3.0.3
         with:
           dotnet-version: |
             3.1.x
@@ -53,7 +53,7 @@ jobs:
         run: dotnet cake --target=Pack
         shell: pwsh
       - name: "Publish Artefacts"
-        uses: actions/upload-artifact@v3.1.0
+        uses: actions/upload-artifact@v3.1.1
         if: always()
         with:
           name: ${{matrix.os}}
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.1
         with:
           path: "./Artefacts"
       - name: "Publish Test Summary"
@@ -89,7 +89,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.1
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Add Source"
@@ -109,7 +109,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: "Download Artefact"
-        uses: actions/download-artifact@v3.0.0
+        uses: actions/download-artifact@v3.0.1
         with:
           name: "windows-latest"
       - name: "Dotnet NuGet Push"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -20,6 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Draft Release"
-        uses: release-drafter/release-drafter@v5.21.0
+        uses: release-drafter/release-drafter@v5.21.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.3.44" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.3.48" />
     <PackageReference Include="MinVer" PrivateAssets="all" Version="4.2.0" />
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.435" />
   </ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,9 +24,9 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" Version="17.3.48" />
-    <PackageReference Include="MinVer" PrivateAssets="all" Version="4.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" PrivateAssets="all" Version="1.2.0-beta.435" />
+    <GlobalPackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.3.48" />
+    <GlobalPackageReference Include="MinVer" Version="4.2.0" />
+    <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.435" />
   </ItemGroup>
 
 </Project>

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1;net472;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Package">
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="Serilog" Version="2.8.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
   </ItemGroup>
 

--- a/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
+++ b/Source/Serilog.Enrichers.Span/Serilog.Enrichers.Span.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup Label="Package References">
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -3,11 +3,11 @@
   <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" />
 
   <ItemGroup Label="Package References">
-    <PackageReference Include="coverlet.collector" PrivateAssets="All" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" PrivateAssets="All" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.114" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" PrivateAssets="All" Version="2.4.5">

--- a/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
+++ b/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net6.0;net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
+++ b/Tests/Serilog.Enrichers.Span.Test/Serilog.Enrichers.Span.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Build">
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net7.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Label="Project References">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,10 +49,10 @@ stages:
               packageType: "sdk"
               version: 3.1.x
           - task: UseDotNet@2
-            displayName: "Install .NET Core 5.0 SDK"
+            displayName: "Install .NET Core 6.0 SDK"
             inputs:
               packageType: "sdk"
-              version: 5.0.x
+              version: 6.0.x
           - task: UseDotNet@2
             displayName: "Install .NET Core SDK"
             inputs:

--- a/build.cake
+++ b/build.cake
@@ -51,9 +51,9 @@ Task("Test")
                     Configuration = configuration,
                     Loggers = new string[]
                     {
-                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                        $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
-                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                        $"trx;LogFilePrefix={project.GetFilenameWithoutExtension()}",
+                        $"junit;LogFilePrefix={project.GetFilenameWithoutExtension()}",
+                        $"html;LogFilePrefix={project.GetFilenameWithoutExtension()}",
                     },
                     NoBuild = true,
                     NoRestore = true,

--- a/build.cake
+++ b/build.cake
@@ -38,26 +38,28 @@ Task("Build")
 
 Task("Test")
     .Description("Runs unit tests and outputs test results to the artefacts directory.")
-    .DoesForEach(GetFiles("./Tests/**/*.csproj"), project =>
-    {
-        DotNetTest(
-            project.ToString(),
-            new DotNetTestSettings()
-            {
-                Blame = true,
-                Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
-                Configuration = configuration,
-                Loggers = new string[]
+    .DoesForEach(
+        GetFiles("./Tests/**/*.csproj"),
+        project =>
+        {
+            DotNetTest(
+                project.ToString(),
+                new DotNetTestSettings()
                 {
-                    $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
-                    $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
-                    $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
-                },
-                NoBuild = true,
-                NoRestore = true,
-                ResultsDirectory = artefactsDirectory,
-            });
-    });
+                    Blame = true,
+                    Collectors = new string[] { "Code Coverage", "XPlat Code Coverage" },
+                    Configuration = configuration,
+                    Loggers = new string[]
+                    {
+                        $"trx;LogFileName={project.GetFilenameWithoutExtension()}.trx",
+                        $"junit;LogFileName={project.GetFilenameWithoutExtension()}.xml",
+                        $"html;LogFileName={project.GetFilenameWithoutExtension()}.html",
+                    },
+                    NoBuild = true,
+                    NoRestore = true,
+                    ResultsDirectory = artefactsDirectory,
+                });
+        });
 
 Task("Pack")
     .Description("Creates NuGet packages and outputs them to the artefacts directory.")

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "2.3.0",
+      "version": "3.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "6.0.402"
+    "version": "7.0.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "allowPrerelease": true,
+    "allowPrerelease": false,
     "rollForward": "latestMajor",
-    "version": "7.0.100-rc.1.22431.12"
+    "version": "7.0.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -2,6 +2,6 @@
   "sdk": {
     "allowPrerelease": true,
     "rollForward": "latestMajor",
-    "version": "7.0.100"
+    "version": "7.0.100-rc.1.22431.12"
   }
 }


### PR DESCRIPTION
- Add .NET 7 target.
- Drop .NET 5 and 3.1 target.
- Update build scripts to install .NET 7 and 6 and stop installing 5 and 3.1.
- Uses C# 11 features resulting in cleaner code.
- Use `GlobalPackageReference`
- Switch `dotnet test --logger` to use `LogFilePrefix`.