### PR TITLE
feat: add ActivityOperationNameEnricher + tests

### DIFF
--- a/Source/Serilog.Enrichers.Span/ActivityOperationNameEnricher.cs
+++ b/Source/Serilog.Enrichers.Span/ActivityOperationNameEnricher.cs
@@ -1,0 +1,62 @@
+namespace Serilog.Enrichers.Span;
+
+using System;
+using System.Diagnostics;
+using Serilog.Core;
+using Serilog.Events;
+
+/// <summary>
+/// A log event enricher which adds baggage from the current <see cref="Activity"/>.
+/// </summary>
+public class ActivityOperationNameEnricher : ILogEventEnricher
+{
+    private readonly SpanLogEventPropertiesNames propertiesNames;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ActivityOperationNameEnricher"/> class.
+    /// </summary>
+    /// <param name="logEventPropertiesNames">Names for log event properties.</param>
+    public ActivityOperationNameEnricher(SpanLogEventPropertiesNames logEventPropertiesNames)
+    {
+        CheckPropertiesNamesArgument(logEventPropertiesNames);
+        this.propertiesNames = logEventPropertiesNames;
+    }
+
+    /// <summary>
+    /// Enrich the log event.
+    /// </summary>
+    /// <param name="logEvent">The log event to enrich.</param>
+    /// <param name="propertyFactory">Factory for creating new properties to add to the event.</param>
+    public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+    {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(logEvent);
+#else
+        if (logEvent is null)
+        {
+            throw new ArgumentNullException(nameof(logEvent));
+        }
+#endif
+
+        var activity = Activity.Current;
+        if (activity is not null)
+        {
+            var operationName = activity.OperationName;
+            logEvent.AddPropertyIfAbsent(new LogEventProperty(this.propertiesNames.OperationName, new ScalarValue(operationName)));
+        }
+    }
+
+    private static void CheckPropertiesNamesArgument(SpanLogEventPropertiesNames logEventPropertyNames)
+    {
+#if NET6_0_OR_GREATER
+#pragma warning disable IDE0022
+        ArgumentNullException.ThrowIfNull(logEventPropertyNames);
+#pragma warning restore IDE0022
+#else
+        if (logEventPropertyNames is null)
+        {
+            throw new ArgumentNullException(nameof(logEventPropertyNames));
+        }
+#endif
+    }
+}

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -52,6 +52,11 @@ public static class LoggerEnrichmentConfigurationExtensions
             loggerEnrichmentConfiguration.With<ActivityBaggageEnricher>();
         }
 
+        if (spanOptions.IncludeOperationName)
+        {
+            loggerEnrichmentConfiguration.With(new ActivityOperationNameEnricher(spanOptions.LogEventPropertiesNames));
+        }
+
         return loggerEnrichmentConfiguration.With(new ActivityEnricher(spanOptions.LogEventPropertiesNames));
     }
 }

--- a/Source/Serilog.Enrichers.Span/SpanLogEventPropertiesNames.cs
+++ b/Source/Serilog.Enrichers.Span/SpanLogEventPropertiesNames.cs
@@ -10,6 +10,7 @@ public class SpanLogEventPropertiesNames
     private string parentId = "ParentId";
     private string traceId = "TraceId";
     private string spanId = "SpanId";
+    private string operationName = "OperationName";
 
     /// <summary>
     /// Gets or sets a name for trace id property.
@@ -59,6 +60,23 @@ public class SpanLogEventPropertiesNames
             }
 
             this.spanId = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets a name for operation name property.
+    /// </summary>
+    public string OperationName
+    {
+        get => this.operationName;
+        set
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new ArgumentException("The property must not be empty", nameof(this.OperationName));
+            }
+
+            this.operationName = value;
         }
     }
 }

--- a/Source/Serilog.Enrichers.Span/SpanOptions.cs
+++ b/Source/Serilog.Enrichers.Span/SpanOptions.cs
@@ -16,6 +16,11 @@ public class SpanOptions
     public bool IncludeBaggage { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether to include operation name in log or not. Default is false.
+    /// </summary>
+    public bool IncludeOperationName { get; set; }
+
+    /// <summary>
     /// Gets or sets log properties names for span.
     /// </summary>
     public SpanLogEventPropertiesNames LogEventPropertiesNames { get; set; } = new();

--- a/Tests/Serilog.Enrichers.Span.Test/ActivityOperationNameEnricherTest.cs
+++ b/Tests/Serilog.Enrichers.Span.Test/ActivityOperationNameEnricherTest.cs
@@ -1,0 +1,81 @@
+namespace Serilog.Enrichers.Span.Test;
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using Moq;
+using Serilog.Core;
+using Serilog.Enrichers.Span;
+using Serilog.Events;
+using Serilog.Parsing;
+using Xunit;
+
+public class ActivityOperationNameEnricherTest
+{
+    private static readonly ActivitySource Source = new("Sample.DistributedTracing", "1.0.0");
+
+    private static readonly ActivityListener Listener = new()
+    {
+        ShouldListenTo = _ => true,
+        Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+    };
+
+    public ActivityOperationNameEnricherTest() => ActivitySource.AddActivityListener(Listener);
+
+    [Fact]
+    public void Given_no_configuration_When_no_custom_names_for_event_properties_Then_the_default_configuration_is_applied()
+    {
+        using var act = Source.StartActivity();
+        var names = new SpanLogEventPropertiesNames();
+        var class1 = new ActivityOperationNameEnricher(names);
+        var @event = MakeLogEvent();
+        class1.Enrich(@event, Mock.Of<ILogEventPropertyFactory>());
+
+        var eventPropertiesNames = @event.Properties.Keys;
+        Assert.Collection(eventPropertiesNames, s => Assert.Equal(names.OperationName, s));
+    }
+
+    [Fact]
+    public void Given_config_with_names_When_custom_names_for_event_properties_Then_the_configuration_is_applied()
+    {
+        using var act = Source.StartActivity();
+        var names = new SpanLogEventPropertiesNames { ParentId = "p", SpanId = "s", TraceId = "t", OperationName = "o" };
+        var class1 =
+            new ActivityOperationNameEnricher(names);
+
+        var @event = MakeLogEvent();
+        class1.Enrich(@event, Mock.Of<ILogEventPropertyFactory>());
+
+        var eventPropertiesNames = @event.Properties.Keys;
+        Assert.Collection(eventPropertiesNames, s => Assert.Equal(names.OperationName, s));
+    }
+
+    [Fact]
+    public void Given_config_with_no_configuration_When_null_for_event_properties_Then_argument_exception_occurs()
+    {
+        using var act = Source.StartActivity();
+        var exception = Assert.Throws<ArgumentNullException>(() => new ActivityOperationNameEnricher(null!));
+        Assert.Equal("logEventPropertyNames", exception.ParamName);
+    }
+
+    [Fact]
+    public void Given_config_with_no_OperationName_name_When_null_name_for_ParentId_event_property_Then_argument_exception_occurs()
+    {
+        using var act = Source.StartActivity();
+        var exception = Assert.Throws<ArgumentException>(() => new SpanLogEventPropertiesNames
+        {
+            OperationName = null!,
+        });
+        Assert.Equal($"The property must not be empty (Parameter '{nameof(SpanLogEventPropertiesNames.OperationName)}')", exception.Message);
+        Assert.Equal(nameof(SpanLogEventPropertiesNames.OperationName), exception.ParamName);
+    }
+
+    private static LogEvent MakeLogEvent() =>
+        new(
+            DateTimeOffset.Now,
+            LogEventLevel.Information,
+            null,
+            new MessageTemplate(
+                new List<MessageTemplateToken>()),
+            new List<LogEventProperty>());
+}


### PR DESCRIPTION
pull request for [#68](https://github.com/RehanSaeed/Serilog.Enrichers.Span/issues/68)

add option in the SpanOptions for IncludeOperationName.
add ActivityOperationNameEnricher 
some test similar to `ActivityEnricherTest` added

Let me know if further changes needed 