### PR TITLE
feat: support augmenting trace context properties

### DIFF
--- a/Source/Serilog.Enrichers.Span/ISpanLogEventPropertyAugmentor.cs
+++ b/Source/Serilog.Enrichers.Span/ISpanLogEventPropertyAugmentor.cs
@@ -1,0 +1,33 @@
+namespace Serilog.Enrichers.Span;
+
+using System.Collections.Generic;
+using Serilog.Events;
+
+/// <summary>
+/// Generates additional log event properties to augment the representation of the trace context of a log message. This
+/// can be used to create additional log event properties with alternative names or representations of property values
+/// to satisfy alternative tracing conventions.
+/// </summary>
+public interface ISpanLogEventPropertyAugmentor
+{
+    /// <summary>
+    /// Generates additional log event properties to augment the representation of the TraceId.
+    /// </summary>
+    /// <param name="traceId">The value of the TraceId to augment.</param>
+    /// <returns>Zero or more additional log event properties to represent the TraceId.</returns>
+    IEnumerable<LogEventProperty> AugmentTraceId(string traceId);
+
+    /// <summary>
+    /// Generates additional log event properties to augment the representation of the SpanId.
+    /// </summary>
+    /// <param name="spanId">The value of the SpanId to augment.</param>
+    /// <returns>Zero or more additional log event properties to represent the SpanId.</returns>
+    IEnumerable<LogEventProperty> AugmentSpanId(string spanId);
+
+    /// <summary>
+    /// Generates additional log event properties to augment the representation of the ParentId.
+    /// </summary>
+    /// <param name="parentId">The value of the ParentId to augment.</param>
+    /// <returns>Zero or more additional log event properties to represent the ParentId.</returns>
+    IEnumerable<LogEventProperty> AugmentParentId(string parentId);
+}

--- a/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
+++ b/Source/Serilog.Enrichers.Span/LoggerEnrichmentConfigurationExtensions.cs
@@ -57,6 +57,6 @@ public static class LoggerEnrichmentConfigurationExtensions
             loggerEnrichmentConfiguration.With(new ActivityOperationNameEnricher(spanOptions.LogEventPropertiesNames));
         }
 
-        return loggerEnrichmentConfiguration.With(new ActivityEnricher(spanOptions.LogEventPropertiesNames));
+        return loggerEnrichmentConfiguration.With(new ActivityEnricher(spanOptions.LogEventPropertiesNames, spanOptions.LogEventPropertyAugmentor));
     }
 }

--- a/Source/Serilog.Enrichers.Span/PropertyAugmentors/DatadogPropertyAugmentor.cs
+++ b/Source/Serilog.Enrichers.Span/PropertyAugmentors/DatadogPropertyAugmentor.cs
@@ -1,0 +1,125 @@
+namespace Serilog.Enrichers.Span.TraceFormatConverters;
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Serilog.Events;
+
+/// <summary>
+/// Converts OTEL trace values to the format expected by Datadog.
+/// </summary>
+/// <remarks>
+/// OTEL trace and span IDs are 16-byte and 8-byte values respectively and are commonly represented as hex strings, but
+/// Datadog expects 64-bit decimal values for both. This converter implements the recommendation from Datadog's
+/// documentation to represent the right-most 8 bytes of each value as a 64-bit integer.
+/// </remarks>
+public class DatadogPropertyAugmentor : ISpanLogEventPropertyAugmentor
+{
+    /// <summary>
+    /// The default field name to use for generated trace ID properties.
+    /// </summary>
+    public const string DefaultTraceIdName = "dd.trace_id";
+
+    /// <summary>
+    /// The default field name to use for generated span ID properties.
+    /// </summary>
+    public const string DefaultSpanIdName = "dd.span_id";
+
+    private readonly string traceIdName;
+    private readonly string spanIdName;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DatadogPropertyAugmentor"/> class.
+    /// </summary>
+    /// <param name="traceIdName">The property name to use for generated trace IDs.</param>
+    /// <param name="spanIdName">The property name to use for generated span IDs.</param>
+    public DatadogPropertyAugmentor(
+        string traceIdName = DefaultTraceIdName,
+        string spanIdName = DefaultSpanIdName)
+    {
+        if (string.IsNullOrWhiteSpace(traceIdName))
+        {
+            throw new ArgumentException("The value must not be empty", nameof(traceIdName));
+        }
+
+        if (string.IsNullOrWhiteSpace(spanIdName))
+        {
+            throw new ArgumentException("The value must not be empty", nameof(spanIdName));
+        }
+
+        this.traceIdName = traceIdName;
+        this.spanIdName = spanIdName;
+    }
+
+    /// <summary>
+    /// Converts 16-byte hex string values into decimal representations of the right-most 8 bytes.
+    /// </summary>
+    /// <param name="traceId">The trace ID to convert.</param>
+    /// <returns>
+    /// A <see cref="LogEventProperty"/> containing then decimal representation of the right-most 8 bytes of
+    /// <paramref name="traceId"/> if its value is a 16-byte hex string, otherwise an empty <see cref="IEnumerable{T}"/>.
+    /// </returns>
+    public IEnumerable<LogEventProperty> AugmentTraceId(string traceId)
+    {
+        if (traceId.Length != 32)
+        {
+            return Array.Empty<LogEventProperty>();
+        }
+
+        try
+        {
+#if NET6_0_OR_GREATER
+            var convertedTraceId = ConvertHexToDecimal(traceId[16..]);
+#else
+            var convertedTraceId = ConvertHexToDecimal(traceId.Substring(16));
+#endif
+
+            return new[]
+            {
+                new LogEventProperty(this.traceIdName, new ScalarValue(convertedTraceId)),
+            };
+        }
+        catch
+        {
+            return Array.Empty<LogEventProperty>();
+        }
+    }
+
+    /// <summary>
+    /// Converts 8-byte hex string values into decimal representation.
+    /// </summary>
+    /// <param name="spanId">The span ID to convert.</param>
+    /// <returns>
+    /// A <see cref="LogEventProperty"/> containing the decimal representation of <paramref name="spanId"/> if its value
+    /// is an 8-byte hex string, otherwise an empty <see cref="IEnumerable{T}"/>.
+    /// </returns>
+    public IEnumerable<LogEventProperty> AugmentSpanId(string spanId)
+    {
+        if (spanId.Length != 16)
+        {
+            return Array.Empty<LogEventProperty>();
+        }
+
+        try
+        {
+            return new[]
+            {
+                new LogEventProperty(this.spanIdName, new ScalarValue(ConvertHexToDecimal(spanId))),
+            };
+        }
+        catch
+        {
+            return Array.Empty<LogEventProperty>();
+        }
+    }
+
+    /// <summary>
+    /// Returns an empty <see cref="IEnumerable{T}"/> because Datadog has no expectation about parent IDs in logs.
+    /// </summary>
+    /// <param name="parentId">The parent ID to convert.</param>
+    /// <returns>An empty <see cref="IEnumerable{T}"/> of <see cref="LogEvent"/>.</returns>
+    public IEnumerable<LogEventProperty> AugmentParentId(string parentId) => Array.Empty<LogEventProperty>();
+
+    private static string ConvertHexToDecimal(string maybeHex) =>
+        Convert.ToUInt64(maybeHex, fromBase: 16).ToString("D", new CultureInfo("en-us"));
+}

--- a/Source/Serilog.Enrichers.Span/SpanOptions.cs
+++ b/Source/Serilog.Enrichers.Span/SpanOptions.cs
@@ -24,4 +24,9 @@ public class SpanOptions
     /// Gets or sets log properties names for span.
     /// </summary>
     public SpanLogEventPropertiesNames LogEventPropertiesNames { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the augmentor to apply to trace values added to the log event.
+    /// </summary>
+    public ISpanLogEventPropertyAugmentor? LogEventPropertyAugmentor { get; set; }
 }

--- a/Tests/Serilog.Enrichers.Span.Test/ActivityEnricherTest.cs
+++ b/Tests/Serilog.Enrichers.Span.Test/ActivityEnricherTest.cs
@@ -3,6 +3,7 @@ namespace Serilog.Enrichers.Span.Test;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using Moq;
 using Serilog.Core;
 using Serilog.Enrichers.Span;
@@ -60,7 +61,7 @@ public class ActivityEnricherTest
     public void Given_config_with_no_configuration_When_null_for_event_properties_Then_argument_exception_occurs()
     {
         using var act = Source.StartActivity();
-        var exception = Assert.Throws<ArgumentNullException>(() => new ActivityEnricher(null!));
+        var exception = Assert.Throws<ArgumentNullException>(() => new ActivityEnricher((null as SpanLogEventPropertiesNames)!));
         Assert.Equal("logEventPropertyNames", exception.ParamName);
     }
 
@@ -98,6 +99,72 @@ public class ActivityEnricherTest
         });
         Assert.Equal($"The property must not be empty (Parameter '{nameof(SpanLogEventPropertiesNames.SpanId)}')", exception.Message);
         Assert.Equal(nameof(SpanLogEventPropertiesNames.SpanId), exception.ParamName);
+    }
+
+    [Fact]
+    public void Given_augmentor_When_augmentor_produces_properties_Then_additional_properties_are_added()
+    {
+        using var act = Source.StartActivity();
+
+        var expectedSpanIdProperties = new[]
+        {
+            new LogEventProperty("alternate-span-id-name-1", new ScalarValue("alternate-span-id-1")),
+            new LogEventProperty("alternate-span-id-name-2", new ScalarValue("alternate-span-id-2")),
+        };
+
+        var expectedTraceIdProperties = new[]
+        {
+            new LogEventProperty("alternate-trace-id-name-1", new ScalarValue("alternate-trace-id-1")),
+        };
+
+        var expectedParentIdProperties = Array.Empty<LogEventProperty>();
+
+        var traceFormatConverter = new Mock<ISpanLogEventPropertyAugmentor>();
+        traceFormatConverter.Setup(x => x.AugmentSpanId(It.IsAny<string>())).Returns(expectedSpanIdProperties);
+        traceFormatConverter.Setup(x => x.AugmentTraceId(It.IsAny<string>())).Returns(expectedTraceIdProperties);
+        traceFormatConverter.Setup(x => x.AugmentParentId(It.IsAny<string>())).Returns(expectedParentIdProperties);
+
+        var class1 = new ActivityEnricher(traceFormatConverter.Object);
+
+        var @event = MakeLogEvent();
+        class1.Enrich(@event, Mock.Of<ILogEventPropertyFactory>());
+
+        var expectedProperties = expectedSpanIdProperties
+            .Concat(expectedTraceIdProperties)
+            .Concat(expectedParentIdProperties);
+
+        foreach (var expected in expectedProperties)
+        {
+            Assert.Contains(@event.Properties, entry => entry.Key == expected.Name && entry.Value == expected.Value);
+        }
+    }
+
+    [Fact]
+    public void Given_augmentor_When_additional_property_names_match_standard_names_Additional_properties_override_standard_properties()
+    {
+        using var act = Source.StartActivity();
+
+        var propertyNames = new SpanLogEventPropertiesNames { ParentId = "p", SpanId = "s", TraceId = "t" };
+
+        var expectedSpanIdProperties = new[]
+        {
+            new LogEventProperty(propertyNames.SpanId, new ScalarValue("alternate-span-id-1")),
+        };
+
+        var expectedTraceIdProperties = Array.Empty<LogEventProperty>();
+        var expectedParentIdProperties = Array.Empty<LogEventProperty>();
+
+        var traceFormatConverter = new Mock<ISpanLogEventPropertyAugmentor>();
+        traceFormatConverter.Setup(x => x.AugmentSpanId(It.IsAny<string>())).Returns(expectedSpanIdProperties);
+        traceFormatConverter.Setup(x => x.AugmentTraceId(It.IsAny<string>())).Returns(expectedTraceIdProperties);
+        traceFormatConverter.Setup(x => x.AugmentParentId(It.IsAny<string>())).Returns(expectedParentIdProperties);
+
+        var class1 = new ActivityEnricher(traceFormatConverter.Object);
+
+        var @event = MakeLogEvent();
+        class1.Enrich(@event, Mock.Of<ILogEventPropertyFactory>());
+
+        Assert.Contains(@event.Properties, entry => entry.Key == propertyNames.SpanId && entry.Value == expectedSpanIdProperties[0].Value);
     }
 
     private static LogEvent MakeLogEvent() =>

--- a/Tests/Serilog.Enrichers.Span.Test/PropertyAugmentors/DatadogPropertyAugmentorTest.cs
+++ b/Tests/Serilog.Enrichers.Span.Test/PropertyAugmentors/DatadogPropertyAugmentorTest.cs
@@ -1,0 +1,95 @@
+namespace Serilog.Enrichers.Span.Test.TraceFormatConverters;
+
+using System.Linq;
+using Serilog.Enrichers.Span.TraceFormatConverters;
+using Serilog.Events;
+using Xunit;
+
+public class DatadogPropertyAugmentorTest
+{
+    [Fact]
+    public void Converting_TraceId_When_input_is_16_byte_hex_string_Rightmost_8_bytes_are_converted_to_uint64()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentTraceId("ebe1010db7d9a5dec2b4a9915c2c79f0").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(new ScalarValue("14030025180947708400"), property.Value);
+    }
+
+    [Fact]
+    public void Converting_TraceId_When_no_property_name_is_given_Property_has_default_name()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentTraceId("ebe1010db7d9a5dec2b4a9915c2c79f0").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(DatadogPropertyAugmentor.DefaultTraceIdName, property.Name);
+    }
+
+    [Fact]
+    public void Converting_TraceId_When_property_name_is_given_Property_has_specified_name()
+    {
+        var expectedTraceIdName = "expected-trace-id-name";
+        var class1 = new DatadogPropertyAugmentor(traceIdName: expectedTraceIdName);
+        var additionalProperties = class1.AugmentTraceId("ebe1010db7d9a5dec2b4a9915c2c79f0").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(expectedTraceIdName, property.Name);
+    }
+
+    [Fact]
+    public void Converting_TraceId_When_input_is_not_a_16_byte_hex_string_No_property_generated()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentTraceId("some-trace-id");
+        Assert.Empty(additionalProperties);
+    }
+
+    [Fact]
+    public void Converting_SpanId_When_input_is_8_byte_hex_string_Value_is_converted_to_uint64()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentSpanId("69e9851f1ca02b9a").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(new ScalarValue("7631777412226755482"), property.Value);
+    }
+
+    [Fact]
+    public void Converting_SpanId_When_no_property_name_is_given_Property_has_default_name()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentSpanId("69e9851f1ca02b9a").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(DatadogPropertyAugmentor.DefaultSpanIdName, property.Name);
+    }
+
+    [Fact]
+    public void Converting_SpanId_When_property_name_is_given_Property_has_specified_name()
+    {
+        var expectedSpanIdName = "expected-span-id-name";
+        var class1 = new DatadogPropertyAugmentor(spanIdName: expectedSpanIdName);
+        var additionalProperties = class1.AugmentSpanId("69e9851f1ca02b9a").ToList();
+        Assert.Single(additionalProperties);
+        var property = additionalProperties[0];
+        Assert.Equal(expectedSpanIdName, property.Name);
+    }
+
+    [Fact]
+    public void Converting_SpanId_Input_is_not_a_8_byte_hex_string_No_property_generated()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var additionalProperties = class1.AugmentSpanId("some-span-id");
+        Assert.Empty(additionalProperties);
+    }
+
+    [Fact]
+    public void Converting_ParentId_No_property_generated()
+    {
+        var class1 = new DatadogPropertyAugmentor();
+        var converted = class1.AugmentParentId("69e9851f1ca02b9a");
+        Assert.Empty(converted);
+    }
+}


### PR DESCRIPTION
Add a property to SpanOptions to support optionally augmenting log events with additional properties to represent the trace context. This is to support the case where the destination that logs will be shipped to expects different property names or differently formatted values to represent traces than what is used natively by the application.

closes: RehanSaeed/Serilog.Enrichers.Span#240
